### PR TITLE
fix: changing show objects on select

### DIFF
--- a/iHog/iHog/Model/ChosenShow.swift
+++ b/iHog/iHog/Model/ChosenShow.swift
@@ -5,141 +5,198 @@
 //  Created by Jay Wilson on 6/9/21.
 //
 
+import CoreData
 import Foundation
 
 class ChosenShow: ObservableObject {
-//    private var id: UUID
-    
-    @Published var scenes: [ShowObject]
-    @Published var lists: [ShowObject]
-    @Published var groups: [ShowObject]
-    @Published var palettes: [ShowObject]
-    
-    var playbackObjects: [ShowObject] {
-        return lists + scenes
-    }
-    
-    init(){
-        scenes = []
-        lists = []
-        groups = []
-        palettes = []
-    }
-    
-    // MARK: Scenes
-    func addScene(_ obj: ShowObject) {
-        if obj.objType == .scene {
-            scenes.append(obj)
+  @Published var scenes: [ShowObject]
+  @Published var lists: [ShowObject]
+  @Published var groups: [ShowObject]
+  @Published var palettes: [ShowObject]
+
+  var playbackObjects: [ShowObject] {
+    return lists + scenes
+  }
+
+  var persistence: PersistenceController
+  var showID: String
+
+  init(showID: String, persistence: PersistenceController) {
+    scenes = []
+    lists = []
+    groups = []
+    palettes = []
+    self.persistence = persistence
+    self.showID = showID
+    getAllObjects()
+  }
+
+  func getAllObjects() {
+    let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "ShowObjectEntity")
+    fetchRequest.predicate = NSPredicate(format: "showID == %@", showID)
+    do {
+      let results =
+        try persistence.container.viewContext.fetch(fetchRequest) as! [CDShowObjectEntity]
+      for showObj in results {
+        var newObj = ShowObject(
+          id: showObj.id!,
+          objType: .group,
+          number: showObj.number,
+          name: showObj.name,
+          objColor: showObj.objColor ?? "red",
+          isOutlined: showObj.isOutlined
+        )
+        switch showObj.objType {
+          case ShowObjectType.group.rawValue:
+            addGroup(newObj)
+          case ShowObjectType.intensity.rawValue:
+            newObj.objType = .intensity
+            addPalette(newObj)
+          case ShowObjectType.position.rawValue:
+            newObj.objType = .position
+            addPalette(newObj)
+          case ShowObjectType.color.rawValue:
+            newObj.objType = .color
+            addPalette(newObj)
+          case ShowObjectType.beam.rawValue:
+            newObj.objType = .beam
+            addPalette(newObj)
+          case ShowObjectType.effect.rawValue:
+            newObj.objType = .effect
+            addPalette(newObj)
+          case ShowObjectType.list.rawValue:
+            newObj.objType = .list
+            addList(newObj)
+          case ShowObjectType.scene.rawValue:
+            newObj.objType = .scene
+            addScene(newObj)
+          default:
+            continue
         }
+      }
+      groups.sort(by: { $0.number < $1.number })
+      palettes.sort(by: { $0.number < $1.number })
+      lists.sort(by: { $0.number < $1.number })
+      scenes.sort(by: { $0.number < $1.number })
+    } catch {
+      Analytics.shared.logError(with: error, for: .coreData, level: .critical)
     }
-    
-    func updateScene(_ obj: ShowObject) {
-        print(obj)
-        if obj.objType == .scene {
-            let index = scenes.firstIndex{ $0.id == obj.id }
-            if index != nil {
-                scenes[index!].setName(obj.name)
-                scenes[index!].setNumber(obj.number)
-                scenes[index!].setColor(obj.getColorString())
-                scenes[index!].setOutline(obj.getOutlineState())
-            } else {
-                print("UPDATE SHOULD NOT HAVE BEEN CALLED")
-            }
+  }
+
+  // MARK: Scenes
+  func addScene(_ obj: ShowObject) {
+    if obj.objType == .scene {
+      scenes.append(obj)
+    }
+  }
+
+  func updateScene(_ obj: ShowObject) {
+    print(obj)
+    if obj.objType == .scene {
+      let index = scenes.firstIndex { $0.id == obj.id }
+      if index != nil {
+        scenes[index!].setName(obj.name)
+        scenes[index!].setNumber(obj.number)
+        scenes[index!].setColor(obj.getColorString())
+        scenes[index!].setOutline(obj.getOutlineState())
+      } else {
+        print("UPDATE SHOULD NOT HAVE BEEN CALLED")
+      }
+    }
+  }
+
+  func removeScene(_ obj: ShowObject) {
+    if obj.objType == .scene {
+      scenes.removeAll { $0.id == obj.id }
+    }
+  }
+  // MARK: Lists
+  func addList(_ obj: ShowObject) {
+    if obj.objType == .list {
+      lists.append(obj)
+    }
+  }
+
+  func updateList(_ obj: ShowObject) {
+    if obj.objType == .list {
+      let index = lists.firstIndex { $0.id == obj.id }
+      if index != nil {
+        lists[index!].setName(obj.name)
+        lists[index!].setNumber(obj.number)
+        lists[index!].setColor(obj.getColorString())
+        lists[index!].setOutline(obj.getOutlineState())
+      } else {
+        print("UPDATE SHOULD NOT HAVE BEEN CALLED")
+      }
+    }
+  }
+
+  func removeList(_ obj: ShowObject) {
+    if obj.objType == .list {
+      lists.removeAll { $0.id == obj.id }
+    }
+  }
+
+  // MARK: Groups
+  func addGroup(_ obj: ShowObject) {
+    if obj.objType == .group {
+      groups.append(obj)
+    }
+  }
+
+  func updateGroup(_ obj: ShowObject) {
+    if obj.objType == .group {
+      let index = groups.firstIndex { $0.id == obj.id }
+      if index != nil {
+        groups[index!].setName(obj.name)
+        groups[index!].setNumber(obj.number)
+        groups[index!].setColor(obj.getColorString())
+        groups[index!].setOutline(obj.getOutlineState())
+      } else {
+        print("UPDATE SHOULD NOT HAVE BEEN CALLED")
+      }
+    }
+  }
+
+  func removeGroup(_ obj: ShowObject) {
+    if obj.objType == .group {
+      groups.removeAll { $0.id == obj.id }
+    }
+  }
+
+  // MARK: Palettes
+  func addPalette(_ obj: ShowObject) {
+    switch obj.objType {
+      case .intensity, .color, .position, .effect, .beam:
+        palettes.append(obj)
+      default:
+        break
+    }
+  }
+
+  func updatePalette(_ obj: ShowObject) {
+    switch obj.objType {
+      case .intensity, .color, .position, .effect, .beam:
+        let index = palettes.firstIndex { $0.id == obj.id }
+        if index != nil {
+          palettes[index!].setName(obj.name)
+          palettes[index!].setNumber(obj.number)
+          palettes[index!].setColor(obj.getColorString())
+          palettes[index!].setOutline(obj.getOutlineState())
+        } else {
+          print("UPDATE SHOULD NOT HAVE BEEN CALLED")
         }
+      default:
+        break
     }
-    
-    func removeScene(_ obj: ShowObject) {
-        if obj.objType == .scene {
-            scenes.removeAll{ $0.id == obj.id }
-        }
+  }
+
+  func removePalette(_ obj: ShowObject) {
+    switch obj.objType {
+      case .intensity, .color, .position, .effect, .beam:
+        palettes.removeAll { $0.id == obj.id }
+      default:
+        break
     }
-    // MARK: Lists
-    func addList(_ obj: ShowObject) {
-        if obj.objType == .list {
-            lists.append(obj)
-        }
-    }
-    
-    func updateList(_ obj: ShowObject) {
-        if obj.objType == .list {
-            let index = lists.firstIndex{ $0.id == obj.id }
-            if index != nil {
-                lists[index!].setName(obj.name)
-                lists[index!].setNumber(obj.number)
-                lists[index!].setColor(obj.getColorString())
-                lists[index!].setOutline(obj.getOutlineState())
-            } else {
-                print("UPDATE SHOULD NOT HAVE BEEN CALLED")
-            }
-        }
-    }
-    
-    func removeList(_ obj: ShowObject) {
-        if obj.objType == .list {
-            lists.removeAll{ $0.id == obj.id }
-        }
-    }
-    
-    // MARK: Groups
-    func addGroup(_ obj: ShowObject) {
-        if obj.objType == .group {
-            groups.append(obj)
-        }
-    }
-    
-    func updateGroup(_ obj: ShowObject) {
-        if obj.objType == .group {
-            let index = groups.firstIndex{ $0.id == obj.id }
-            if index != nil {
-                groups[index!].setName(obj.name)
-                groups[index!].setNumber(obj.number)
-                groups[index!].setColor(obj.getColorString())
-                groups[index!].setOutline(obj.getOutlineState())
-            } else {
-                print("UPDATE SHOULD NOT HAVE BEEN CALLED")
-            }
-        }
-    }
-    
-    func removeGroup(_ obj: ShowObject) {
-        if obj.objType == .group {
-            groups.removeAll{ $0.id == obj.id }
-        }
-    }
-    
-    // MARK: Palettes
-    func addPalette(_ obj: ShowObject) {
-        switch obj.objType {
-        case .intensity, .color, .position, .effect, .beam:
-            palettes.append(obj)
-        default:
-            break
-        }
-    }
-    
-    func updatePalette(_ obj: ShowObject) {
-        switch obj.objType {
-        case .intensity, .color, .position, .effect, .beam:
-            let index = palettes.firstIndex{ $0.id == obj.id }
-            if index != nil {
-                palettes[index!].setName(obj.name)
-                palettes[index!].setNumber(obj.number)
-                palettes[index!].setColor(obj.getColorString())
-                palettes[index!].setOutline(obj.getOutlineState())
-            } else {
-                print("UPDATE SHOULD NOT HAVE BEEN CALLED")
-            }
-        default:
-            break
-        }
-    }
-    
-    func removePalette(_ obj: ShowObject) {
-        switch obj.objType {
-        case .intensity, .color, .position, .effect, .beam:
-            palettes.removeAll{ $0.id == obj.id }
-        default:
-            break
-        }
-    }
+  }
 }

--- a/iHog/iHog/Views/Settings/ChooseShowSettings/AllShowsView.swift
+++ b/iHog/iHog/Views/Settings/ChooseShowSettings/AllShowsView.swift
@@ -54,7 +54,13 @@ struct AllShowsView: View {
             ForEach(shows) { show in
               NavigationLink(
                 destination: {
-                  ShowNavigation(selectedShow: show)
+                  ShowNavigation(
+                    selectedShow: show,
+                    chosenShow: ChosenShow(
+                      showID: (show.id ?? UUID()).uuidString,
+                      persistence: .shared
+                    )
+                  )
                 },
                 label: {
                   HStack {
@@ -104,7 +110,13 @@ struct AllShowsView: View {
           ForEach(shows) { show in
             NavigationLink(
               destination: {
-                ShowNavigation(selectedShow: show)
+                ShowNavigation(
+                  selectedShow: show,
+                  chosenShow: ChosenShow(
+                    showID: (show.id ?? UUID()).uuidString,
+                    persistence: .shared
+                  )
+                )
               },
               label: {
                 HStack {

--- a/iHog/iHog/Views/Settings/SettingsView.swift
+++ b/iHog/iHog/Views/Settings/SettingsView.swift
@@ -203,7 +203,17 @@ struct SettingsView: View {
         case let .addView(addView):
           AddViewController(viewToAdd: addView)
         case let .shows(show):
-          ShowNavigation(selectedShow: show)
+          if let showID = show.id {
+            ShowNavigation(
+              selectedShow: show,
+              chosenShow: ChosenShow(
+                showID: showID.uuidString,
+                persistence: PersistenceController.shared
+              )
+            )
+          } else {
+            Text("Something is wrong. Please send an email to support@cctplus.dev")
+          }
         case .osc:
           OSCSettings()
             .navigationTitle("OSC Settings")

--- a/iHog/iHog/Views/ShowObjects/PlaybackObjects.swift
+++ b/iHog/iHog/Views/ShowObjects/PlaybackObjects.swift
@@ -110,7 +110,7 @@ struct PlaybackObjects: View {
     }
     .padding()
     .onAppear {
-      getAllObjects()
+      //      getAllObjects()
     }
   }
 

--- a/iHog/iHog/Views/ShowObjects/ProgrammingObjects.swift
+++ b/iHog/iHog/Views/ShowObjects/ProgrammingObjects.swift
@@ -144,7 +144,7 @@ struct ProgrammingObjects: View {
     }
     .padding()
     .onAppear {
-      getAllObjects()
+      //      getAllObjects()
     }
   }
 

--- a/iHog/iHog/Views/ShowViews/ShowNavigation.swift
+++ b/iHog/iHog/Views/ShowViews/ShowNavigation.swift
@@ -10,9 +10,10 @@ import SwiftUI
 struct ShowNavigation: View {
   @AppStorage(Settings.chosenShowID.rawValue) var chosenShowID: String = ""
   @EnvironmentObject var user: UserState
+
   var selectedShow: CDShowEntity
 
-  @StateObject var chosenShow = ChosenShow()
+  @ObservedObject var chosenShow: ChosenShow
 
   @State private var selectedView: Views = Views.programmingObjects
 
@@ -23,6 +24,7 @@ struct ShowNavigation: View {
     case puntPagePlayback
     case puntPageProgPlay
   }
+
   var body: some View {
     TabView(selection: $selectedView) {
       ProgrammingObjects(show: chosenShow)
@@ -61,7 +63,7 @@ struct ShowNavigation: View {
     }
     .navigationBarTitle(selectedShow.name!)
     .navigationBarTitleDisplayMode(.inline)
-    .onAppear {
+    .task {
       chosenShowID = selectedShow.id!.uuidString
     }
   }


### PR DESCRIPTION
Makes the chosen show be generated whenever a show is selected. All fetching for initial objects is done on show selection. Not sure how it was working before.

Closes #56 

